### PR TITLE
feature/ECCT-571-add-statement-accepted-boolean-to-post-request

### DIFF
--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/mapper/RegisteredEmailAddressMapper.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/mapper/RegisteredEmailAddressMapper.java
@@ -14,6 +14,7 @@ public interface RegisteredEmailAddressMapper {
     RegisteredEmailAddressResponseDTO daoToDto(RegisteredEmailAddressDAO registeredEmailAddressDAO);
 
     @Mapping(target = "data.registeredEmailAddress", source = "registeredEmailAddress")
+    @Mapping(target = "data.acceptAppropriateEmailAddressStatement", source = "acceptAppropriateEmailAddressStatement")
     RegisteredEmailAddressDAO dtoToDao( RegisteredEmailAddressDTO registeredEmailAddressDTO);
 
 

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/model/dao/RegisteredEmailAddressData.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/model/dao/RegisteredEmailAddressData.java
@@ -5,6 +5,8 @@ import org.springframework.data.mongodb.core.mapping.Field;
 public class RegisteredEmailAddressData {
     @Field("registered_email_address")
     private String registeredEmailAddress;
+    @Field("accept_appropriate_email_address_statement")
+    private boolean acceptAppropriateEmailAddressStatement;
     @Field("etag")
     private String etag;
     @Field("kind")
@@ -17,6 +19,15 @@ public class RegisteredEmailAddressData {
     public void setRegisteredEmailAddress(String registeredEmailAddress) {
         this.registeredEmailAddress = registeredEmailAddress;
     }
+
+    public boolean isAcceptAppropriateEmailAddressStatement() {
+        return acceptAppropriateEmailAddressStatement;
+    }
+
+    public void setAcceptAppropriateEmailAddressStatement(boolean acceptAppropriateEmailAddressStatement) {
+        this.acceptAppropriateEmailAddressStatement = acceptAppropriateEmailAddressStatement;
+    }
+
     public String getEtag() {
         return etag;
     }

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/model/dto/RegisteredEmailAddressDTO.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/model/dto/RegisteredEmailAddressDTO.java
@@ -7,21 +7,13 @@ import javax.validation.constraints.Pattern;
 
 
 public class RegisteredEmailAddressDTO {
-
-    @JsonProperty("id")
-    private String id;
     @NotBlank(message = "registered_email_address must not be blank")
     @Pattern(regexp = "^.+@.+\\..+$",
             message ="registered_email_address must have a valid email format" )
     @JsonProperty("registered_email_address")
     private String registeredEmailAddress;
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
+    @JsonProperty("accept_appropriate_email_address_statement")
+    private boolean acceptAppropriateEmailAddressStatement;
 
     public String getRegisteredEmailAddress() {
         return registeredEmailAddress;
@@ -29,6 +21,14 @@ public class RegisteredEmailAddressDTO {
 
     public void setRegisteredEmailAddress(String registeredEmailAddress) {
         this.registeredEmailAddress = registeredEmailAddress;
+    }
+
+    public Boolean getAcceptAppropriateEmailAddressStatement() {
+        return acceptAppropriateEmailAddressStatement;
+    }
+
+    public void setAcceptAppropriateEmailAddressStatement(Boolean acceptAppropriateEmailAddressStatement) {
+        this.acceptAppropriateEmailAddressStatement = acceptAppropriateEmailAddressStatement;
     }
 }
 

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/model/dto/RegisteredEmailAddressDTO.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/model/dto/RegisteredEmailAddressDTO.java
@@ -23,11 +23,11 @@ public class RegisteredEmailAddressDTO {
         this.registeredEmailAddress = registeredEmailAddress;
     }
 
-    public Boolean getAcceptAppropriateEmailAddressStatement() {
+    public boolean isAcceptAppropriateEmailAddressStatement() {
         return acceptAppropriateEmailAddressStatement;
     }
 
-    public void setAcceptAppropriateEmailAddressStatement(Boolean acceptAppropriateEmailAddressStatement) {
+    public void setAcceptAppropriateEmailAddressStatement(boolean acceptAppropriateEmailAddressStatement) {
         this.acceptAppropriateEmailAddressStatement = acceptAppropriateEmailAddressStatement;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/model/dto/RegisteredEmailAddressResponseData.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/model/dto/RegisteredEmailAddressResponseData.java
@@ -2,21 +2,11 @@ package uk.gov.companieshouse.registeredemailaddressapi.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class RegisteredEmailAddressResponseData {
-    @JsonProperty("registered_email_address")
-    private String registeredEmailAddress;
+public class RegisteredEmailAddressResponseData extends RegisteredEmailAddressDTO {
     @JsonProperty("etag")
     private String etag;
     @JsonProperty("kind")
     private String kind;
-
-    public String getRegisteredEmailAddress() {
-        return registeredEmailAddress;
-    }
-
-    public void setRegisteredEmailAddress(String registeredEmailAddress) {
-        this.registeredEmailAddress = registeredEmailAddress;
-    }
     public String getEtag() {
         return etag;
     }

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/service/RegisteredEmailAddressFilingService.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/service/RegisteredEmailAddressFilingService.java
@@ -89,6 +89,7 @@ public class RegisteredEmailAddressFilingService {
         } else {
             data.put(REGISTERED_EMAIL_ADDRESS, registeredEmailAddressSubmission.getData().getRegisteredEmailAddress());
         }
+        data.put(ACCEPT_EMAIL_STATEMENT, registeredEmailAddressSubmission.getData().getAcceptAppropriateEmailAddressStatement());
         ApiLogger.debug(DEBUG_MESSAGE, logMap);
         return registeredEmailAddressSubmission;
     }

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/service/RegisteredEmailAddressFilingService.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/service/RegisteredEmailAddressFilingService.java
@@ -89,7 +89,7 @@ public class RegisteredEmailAddressFilingService {
         } else {
             data.put(REGISTERED_EMAIL_ADDRESS, registeredEmailAddressSubmission.getData().getRegisteredEmailAddress());
         }
-        data.put(ACCEPT_EMAIL_STATEMENT, registeredEmailAddressSubmission.getData().getAcceptAppropriateEmailAddressStatement());
+        data.put(ACCEPT_EMAIL_STATEMENT, registeredEmailAddressSubmission.getData().isAcceptAppropriateEmailAddressStatement());
         ApiLogger.debug(DEBUG_MESSAGE, logMap);
         return registeredEmailAddressSubmission;
     }

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/service/RegisteredEmailAddressService.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/service/RegisteredEmailAddressService.java
@@ -96,8 +96,20 @@ public class RegisteredEmailAddressService {
         ApiLogger.debugContext(requestId, " -  updateRegisteredEmailAddress(...)");
             if (transaction.getStatus() != null && transaction.getStatus().equals(OPEN)) {
                 RegisteredEmailAddressDAO registeredEmailAddress = getRegisteredEmailAddressDAO(transaction.getId(), requestId);
-                registeredEmailAddress.getData()
-                        .setRegisteredEmailAddress(registeredEmailAddressDTO.getRegisteredEmailAddress());
+
+                if(!registeredEmailAddressDTO.getRegisteredEmailAddress().isEmpty()){
+                    registeredEmailAddress.getData()
+                            .setRegisteredEmailAddress(registeredEmailAddressDTO.getRegisteredEmailAddress());
+                }
+
+                if(!registeredEmailAddressDTO.isAcceptAppropriateEmailAddressStatement() ==
+                        registeredEmailAddress.getData().isAcceptAppropriateEmailAddressStatement()){
+                    registeredEmailAddress.getData()
+                            .setAcceptAppropriateEmailAddressStatement(registeredEmailAddressDTO.isAcceptAppropriateEmailAddressStatement());
+                }
+
+
+
                 registeredEmailAddress.setLastModifiedByUserId(userId);
                 registeredEmailAddress.setUpdatedAt(LocalDateTime.now());
                 RegisteredEmailAddressDAO createdRegisteredEmailAddress = registeredEmailAddressRepository

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/service/ValidationService.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/service/ValidationService.java
@@ -8,8 +8,7 @@ import uk.gov.companieshouse.registeredemailaddressapi.model.dao.RegisteredEmail
 import uk.gov.companieshouse.registeredemailaddressapi.utils.ApiLogger;
 import uk.gov.companieshouse.service.rest.err.Errors;
 
-import static uk.gov.companieshouse.registeredemailaddressapi.utils.ValidationUtils.isNotNull;
-import static uk.gov.companieshouse.registeredemailaddressapi.utils.ValidationUtils.isValidEmailAddress;
+import static uk.gov.companieshouse.registeredemailaddressapi.utils.ValidationUtils.*;
 
 @Service
 public class ValidationService {
@@ -29,6 +28,12 @@ public class ValidationService {
                     "registered_email_address",
                     errors,
                     requestId);
+
+            isEmailAddressStatementAccepted(registeredEmailAddress.getData().isAcceptAppropriateEmailAddressStatement(),
+                    "accept_appropriate_email_address_statement",
+                    errors,
+                    requestId);
+
 
         }
         return formatValidationStatusResponse(errors, registeredEmailAddress, requestId);

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/utils/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/utils/Constants.java
@@ -28,6 +28,9 @@ public class Constants {
 
     //submissions
     public static final String REGISTERED_EMAIL_ADDRESS = "registered_email_address";
+
+    public static final String ACCEPT_EMAIL_STATEMENT = "accept_appropriate_email_address_statement";
+
     public static final String COMPANY_NUMBER = "company_number";
     public static final String LINK_SELF = "self";
     public static final String LINK_VALIDATION = "validation_status";

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/utils/ValidationUtils.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/utils/ValidationUtils.java
@@ -11,7 +11,7 @@ public class ValidationUtils {
 
     public static final String NOT_NULL_ERROR_MESSAGE = "%s must not be null";
     public static final String INVALID_EMAIL_ERROR_MESSAGE = "Email address is not in the correct format for %s, like name@example.com";
-
+    public static final String ACCEPTED_EMAIL_ADDRESS_STATEMENT_ERROR_MESSAGE = "The Appropriate Email Address Statement has not been accepted.";
 
     private ValidationUtils() { }
 
@@ -23,7 +23,7 @@ public class ValidationUtils {
         }
         return true;
     }
-    public static boolean isValidEmailAddress(String email, String qualifiedFieldName, Errors errs, String loggingContext) {
+    public static void isValidEmailAddress(String email, String qualifiedFieldName, Errors errs, String loggingContext) {
         var regex = "^.+@.+\\..+$";
         var pattern = Pattern.compile(regex);
         var matcher = pattern.matcher(email);
@@ -31,9 +31,13 @@ public class ValidationUtils {
         if (!matcher.matches()) {
             setErrorMsgToLocation(errs, qualifiedFieldName, String.format(INVALID_EMAIL_ERROR_MESSAGE, qualifiedFieldName));
             ApiLogger.infoContext(loggingContext, "Email address is not in the correct format for " + qualifiedFieldName);
-            return false;
         }
-        return true;
+    }
+    public static void isEmailAddressStatementAccepted(boolean acceptedEmailAddressStatement, String qualifiedFieldName, Errors errs, String loggingContext) {
+        if (!acceptedEmailAddressStatement) {
+            setErrorMsgToLocation(errs, qualifiedFieldName, String.format(ACCEPTED_EMAIL_ADDRESS_STATEMENT_ERROR_MESSAGE, qualifiedFieldName));
+            ApiLogger.infoContext(loggingContext, "The " + qualifiedFieldName + " must be True.");
+        }
     }
 
     public static void setErrorMsgToLocation(Errors errors, String qualifiedFieldName, String msg){

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/RegisteredEmailAddressControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/RegisteredEmailAddressControllerIntegrationTest.java
@@ -124,7 +124,9 @@ public class RegisteredEmailAddressControllerIntegrationTest {
                         .contentType("application/json").header("ERIC-Identity", "123")
                         .header("X-Request-Id", "123456").content(helper.writeToJson(registeredEmailAddressDTO)))
                 .andExpect(status().isOk()).andExpect(jsonPath("$.id").isNotEmpty())
-                .andExpect(jsonPath("$.data.registered_email_address").value("UpdateTest@Test.com"));
+                .andExpect(jsonPath("$.data.registered_email_address").value("UpdateTest@Test.com"))
+                .andExpect(jsonPath("$.data.accept_appropriate_email_address_statement").value(true));
+
     }
 
     //Test Update End points

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/RegisteredEmailAddressControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/RegisteredEmailAddressControllerIntegrationTest.java
@@ -59,7 +59,9 @@ public class RegisteredEmailAddressControllerIntegrationTest {
                         .contentType("application/json").header("ERIC-Identity", "123")
                         .header("X-Request-Id", "123456").content(helper.writeToJson(registeredEmailAddressDTO)))
                 .andExpect(status().isCreated()).andExpect(jsonPath("$.id").isNotEmpty())
-                .andExpect(jsonPath("$.data.registered_email_address").value("Test@Test.com"));
+                .andExpect(jsonPath("$.data.registered_email_address").value("Test@Test.com"))
+                .andExpect(jsonPath("$.data.accept_appropriate_email_address_statement").value(true));
+
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/utils/Helper.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/utils/Helper.java
@@ -24,12 +24,14 @@ public class Helper {
     public RegisteredEmailAddressDTO generateRegisteredEmailAddressDTO(String email){
         RegisteredEmailAddressDTO registeredEmailAddressDTO = new RegisteredEmailAddressDTO();
         registeredEmailAddressDTO.setRegisteredEmailAddress(email);
+        registeredEmailAddressDTO.setAcceptAppropriateEmailAddressStatement(true);
         return registeredEmailAddressDTO;
     }
 
     public RegisteredEmailAddressDAO generateRegisteredEmailAddressDAO(String email, String transactionId){
         RegisteredEmailAddressData registeredEmailAddressData =  new RegisteredEmailAddressData();
         registeredEmailAddressData.setRegisteredEmailAddress(email);
+        registeredEmailAddressData.setAcceptAppropriateEmailAddressStatement(true);
         RegisteredEmailAddressDAO registeredEmailAddressDAO =  new RegisteredEmailAddressDAO();
         registeredEmailAddressDAO.setData(registeredEmailAddressData);
         registeredEmailAddressDAO.setTransactionId(transactionId);
@@ -40,6 +42,7 @@ public class Helper {
     public RegisteredEmailAddressResponseDTO generateRegisteredEmailAddressResponseDTO(String email, String transactionId){
         RegisteredEmailAddressResponseData registeredEmailAddressData =  new RegisteredEmailAddressResponseData();
         registeredEmailAddressData.setRegisteredEmailAddress(email);
+        registeredEmailAddressData.setAcceptAppropriateEmailAddressStatement(true);
         RegisteredEmailAddressResponseDTO registeredEmailAddressResponseDTO =  new RegisteredEmailAddressResponseDTO();
         registeredEmailAddressResponseDTO.setData(registeredEmailAddressData);
         registeredEmailAddressResponseDTO.setId(UUID.randomUUID().toString());

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/controller/RegisteredEmailAddressControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/controller/RegisteredEmailAddressControllerTest.java
@@ -109,8 +109,6 @@ class RegisteredEmailAddressControllerTest {
         ValidationStatusResponse validationStatusResponse = new ValidationStatusResponse();
         validationStatusResponse.setValid(true);
 
-        registeredEmailAddressDTO.setId(UUID.randomUUID().toString());
-
         when(this.registeredEmailAddressService
                 .getValidationStatus(TRANSACTION_ID, REQUEST_ID)).thenReturn(validationStatusResponse);
 

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/RegisteredEmailAddressFilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/RegisteredEmailAddressFilingServiceTest.java
@@ -103,6 +103,7 @@ class RegisteredEmailAddressFilingServiceTest {
         assertEquals("Registered Email Address Filing update statement made 26 March 2023", registeredEmailAddressFiling.getDescription());   
         assertEquals(TEST_EMAIL, registeredEmailAddressFiling.getData().get(REGISTERED_EMAIL_ADDRESS));
         assertEquals(TEST_COMPANY_NUMBER, registeredEmailAddressFiling.getData().get(COMPANY_NUMBER));
+        assertEquals(true, registeredEmailAddressFiling.getData().get(ACCEPT_EMAIL_STATEMENT));
     }
 
     @Test
@@ -130,7 +131,6 @@ class RegisteredEmailAddressFilingServiceTest {
     private RegisteredEmailAddressDTO buildRegisteredEmailAddressDTO() {
         RegisteredEmailAddressDTO registeredEmailAddressDTO = new RegisteredEmailAddressDTO();
         registeredEmailAddressDTO.setRegisteredEmailAddress(TEST_EMAIL);
-        registeredEmailAddressDTO.setId(SUBMISSION_ID);
         return registeredEmailAddressDTO;
     }
 

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/RegisteredEmailAddressServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/RegisteredEmailAddressServiceTest.java
@@ -133,6 +133,7 @@ class RegisteredEmailAddressServiceTest {
         registeredEmailAddressDAO.setUpdatedAt(LocalDateTime.now());
         registeredEmailAddressDAO.getData()
                 .setRegisteredEmailAddress(newEmail);
+        registeredEmailAddressDAO.getData().setAcceptAppropriateEmailAddressStatement(false);
         when(registeredEmailAddressRepository.save(registeredEmailAddressDAO)).thenReturn(registeredEmailAddressDAO);
         when(registeredEmailAddressMapper.daoToDto(any())).thenReturn(registeredEmailAddressResponseDTO);
 
@@ -255,13 +256,14 @@ class RegisteredEmailAddressServiceTest {
     private RegisteredEmailAddressDTO buildRegisteredEmailAddressDTO() {
         RegisteredEmailAddressDTO registeredEmailAddressDTO = new RegisteredEmailAddressDTO();
         registeredEmailAddressDTO.setRegisteredEmailAddress("test@Test.com");
+        registeredEmailAddressDTO.setAcceptAppropriateEmailAddressStatement(true);
         return registeredEmailAddressDTO;
     }
 
     private RegisteredEmailAddressDAO buildRegisteredEmailAddressDAO() {
         RegisteredEmailAddressData registeredEmailAddressData = new RegisteredEmailAddressData();
         registeredEmailAddressData.setRegisteredEmailAddress("test@Test.com");
-
+        registeredEmailAddressData.setAcceptAppropriateEmailAddressStatement(false);
         RegisteredEmailAddressDAO registeredEmailAddressDAO = new RegisteredEmailAddressDAO();
         registeredEmailAddressDAO.setData(registeredEmailAddressData);
         registeredEmailAddressDAO.setId(SUBMISSION_ID);

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/RegisteredEmailAddressServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/RegisteredEmailAddressServiceTest.java
@@ -255,7 +255,6 @@ class RegisteredEmailAddressServiceTest {
     private RegisteredEmailAddressDTO buildRegisteredEmailAddressDTO() {
         RegisteredEmailAddressDTO registeredEmailAddressDTO = new RegisteredEmailAddressDTO();
         registeredEmailAddressDTO.setRegisteredEmailAddress("test@Test.com");
-        registeredEmailAddressDTO.setId(SUBMISSION_ID);
         return registeredEmailAddressDTO;
     }
 

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/ValidationServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/ValidationServiceTest.java
@@ -14,8 +14,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.companieshouse.registeredemailaddressapi.utils.ValidationUtils.INVALID_EMAIL_ERROR_MESSAGE;
-import static uk.gov.companieshouse.registeredemailaddressapi.utils.ValidationUtils.NOT_NULL_ERROR_MESSAGE;
+import static uk.gov.companieshouse.registeredemailaddressapi.utils.ValidationUtils.*;
 
 @ExtendWith(MockitoExtension.class)
 class ValidationServiceTest {
@@ -29,6 +28,7 @@ class ValidationServiceTest {
     void testValidateRegisteredEmailAddressSuccessful() {
         RegisteredEmailAddressData registeredEmailAddressData =  new RegisteredEmailAddressData();
         registeredEmailAddressData.setRegisteredEmailAddress("Test@Test.com");
+        registeredEmailAddressData.setAcceptAppropriateEmailAddressStatement(true);
         RegisteredEmailAddressDAO registeredEmailAddress =  new RegisteredEmailAddressDAO();
         registeredEmailAddress.setData(registeredEmailAddressData);
 
@@ -39,7 +39,7 @@ class ValidationServiceTest {
     }
 
     @Test
-    void testvalidateOfEmptyRegisteredEmailAddress() {
+    void testValidateOfEmptyRegisteredEmailAddress() {
         RegisteredEmailAddressDAO registeredEmailAddress =  new RegisteredEmailAddressDAO();
         registeredEmailAddress.setData(null);
 
@@ -63,6 +63,23 @@ class ValidationServiceTest {
         assertEquals(false, response.isValid());
         assertTrue(Arrays.stream(response.getValidationStatusError()).findFirst().get().getError()
                 .contains( String.format(INVALID_EMAIL_ERROR_MESSAGE, "registered_email_address")));
+
+    }
+
+    @Test
+    void testValidateOfFalseAppropriateEmailAddressStatement() {
+        RegisteredEmailAddressData registeredEmailAddressData =  new RegisteredEmailAddressData();
+        registeredEmailAddressData.setRegisteredEmailAddress("Test@Test.com");
+        registeredEmailAddressData.setAcceptAppropriateEmailAddressStatement(false);
+        RegisteredEmailAddressDAO registeredEmailAddress =  new RegisteredEmailAddressDAO();
+        registeredEmailAddress.setData(registeredEmailAddressData);
+
+        ValidationStatusResponse response = validationService.validateRegisteredEmailAddress(registeredEmailAddress, REQUEST_ID);
+
+        assertEquals(false, response.isValid());
+
+        assertTrue(Arrays.stream(response.getValidationStatusError()).findFirst().get().getError()
+                .contains( String.format(ACCEPTED_EMAIL_ADDRESS_STATEMENT_ERROR_MESSAGE, "accept_appropriate_email_address_statement")));
 
     }
 

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/utils/ValidationUtilsTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/utils/ValidationUtilsTest.java
@@ -12,6 +12,7 @@ import uk.gov.companieshouse.service.rest.err.Errors;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static uk.gov.companieshouse.registeredemailaddressapi.utils.ValidationUtils.INVALID_EMAIL_ERROR_MESSAGE;
+import static uk.gov.companieshouse.registeredemailaddressapi.utils.ValidationUtils.isValidEmailAddress;
 
 @ExtendWith(MockitoExtension.class)
 public class ValidationUtilsTest {
@@ -51,7 +52,13 @@ public class ValidationUtilsTest {
     @Test
     @DisplayName("Validate Email successfully")
     void validateEmail_Successful() {
-        assertTrue(ValidationUtils.isValidEmailAddress(EMAIL_TEST, DUMMY_PARENT_FIELD, errors, LOGGING_CONTEXT));
+        String errMsg = INVALID_EMAIL_ERROR_MESSAGE.replace("%s", DUMMY_PARENT_FIELD);
+        Err err = Err.invalidBodyBuilderWithLocation(DUMMY_PARENT_FIELD).withError(errMsg).build();
+
+        isValidEmailAddress(EMAIL_TEST, DUMMY_PARENT_FIELD, errors, LOGGING_CONTEXT);
+
+        assertEquals(0, errors.size());
+        assertFalse(errors.containsError(err));
     }
 
     @Test
@@ -60,9 +67,8 @@ public class ValidationUtilsTest {
         String errMsg = INVALID_EMAIL_ERROR_MESSAGE.replace("%s", DUMMY_PARENT_FIELD);
         Err err = Err.invalidBodyBuilderWithLocation(DUMMY_PARENT_FIELD).withError(errMsg).build();
 
-        boolean isValidEmail = ValidationUtils.isValidEmailAddress("lorem@ipsum", DUMMY_PARENT_FIELD, errors, LOGGING_CONTEXT);
+        isValidEmailAddress("lorem@ipsum", DUMMY_PARENT_FIELD, errors, LOGGING_CONTEXT);
 
-        assertFalse(isValidEmail);
         assertEquals(1, errors.size());
         assertTrue(errors.containsError(err));
     }


### PR DESCRIPTION
 accept_appropriate_email_address_statement has been added to the RegisteredEmailAddressData and RegisteredEmailAddressDTO.

 isEmailAddressStatementAccepted has been added to the validation check for "/transactions/{"TRANSACTION_ID"/registered-email-address//validation-status"

 RegisteredEmailAddressFilingData now contains accept_appropriate_email_address_statement field