### PR TITLE
ecct-639-check-rea-update-eligibility

### DIFF
--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/client/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/client/ApiClientService.java
@@ -10,6 +10,10 @@ import java.io.IOException;
 @Component
 public class ApiClientService {
 
+    public ApiClient getApiKeyAuthenticatedClient() {
+        return ApiSdkManager.getSDK();
+    }
+
     public ApiClient getOauthAuthenticatedClient(String ericPassThroughHeader) throws IOException {
         return ApiSdkManager.getSDK(ericPassThroughHeader);
     }

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/configuration/ReaServiceEligibilityConfig.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/configuration/ReaServiceEligibilityConfig.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.registeredemailaddressapi.configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.EligibilityRule;
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.impl.CompanyStatusValidation;
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.impl.CompanyTypeValidation;
+
+@Configuration
+public class ReaServiceEligibilityConfig {
+
+    @Value("${allowed.company.statuses}")
+    private Set<String> allowedCompanyStatuses;
+
+    @Value("${allowed.company.types}")
+    private Set<String> allowedCompanyTypes;
+
+    @Bean
+    @Qualifier("rea-update-eligibility-rules")
+    List<EligibilityRule<CompanyProfileApi>> reaUpdateEligibilityRules() {
+        var listOfRules = new ArrayList<EligibilityRule<CompanyProfileApi>>();
+
+        var companyStatusValidation = new CompanyStatusValidation(allowedCompanyStatuses);
+        var companyTypeValidationForWebFiling = new CompanyTypeValidation(allowedCompanyTypes);
+
+        /* Check 1: Company Status */
+        listOfRules.add(companyStatusValidation);
+
+        /* Check 2: Company Type */
+        listOfRules.add(companyTypeValidationForWebFiling);
+
+        return listOfRules;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/controller/EligibilityController.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/controller/EligibilityController.java
@@ -1,0 +1,57 @@
+package uk.gov.companieshouse.registeredemailaddressapi.controller;
+
+import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.ERIC_REQUEST_ID_KEY;
+
+import java.util.HashMap;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.EligibilityStatusCode;
+import uk.gov.companieshouse.registeredemailaddressapi.exception.CompanyNotFoundException;
+import uk.gov.companieshouse.registeredemailaddressapi.model.response.CompanyValidationResponse;
+import uk.gov.companieshouse.registeredemailaddressapi.service.CompanyProfileService;
+import uk.gov.companieshouse.registeredemailaddressapi.service.EligibilityService;
+import uk.gov.companieshouse.registeredemailaddressapi.utils.ApiLogger;
+
+@RestController
+public class EligibilityController {
+
+    @Autowired
+    private CompanyProfileService companyProfileService;
+
+    @Autowired
+    private EligibilityService eligibilityService;
+
+    @GetMapping("/registered-email-address/company/{company-number}/eligibility")
+    public ResponseEntity<CompanyValidationResponse> getEligibility(@PathVariable("company-number") String companyNumber,
+            @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId) {
+
+        var logMap = new HashMap<String, Object>();
+        logMap.put("company_number", companyNumber);
+        ApiLogger.infoContext(requestId, "Calling service to retrieve company eligibility", logMap);
+
+        try {
+            var companyProfile = companyProfileService.getCompanyProfile(companyNumber);
+            var companyValidationResponse = eligibilityService.checkCompanyEligibility(companyProfile);
+
+            if (EligibilityStatusCode.COMPANY_VALID_FOR_SERVICE == companyValidationResponse.getEligibilityStatusCode()) {
+                return ResponseEntity.ok().body(companyValidationResponse);
+            } else {
+                return ResponseEntity.badRequest().body(companyValidationResponse);
+            }
+        } catch (CompanyNotFoundException e) {
+            var companyNotFoundResponse = new CompanyValidationResponse();
+            companyNotFoundResponse.setEligibilityStatusCode(EligibilityStatusCode.COMPANY_NOT_FOUND);
+            return ResponseEntity.badRequest().body(companyNotFoundResponse);
+        } catch (Exception e) {
+            ApiLogger.errorContext(requestId, "Error checking eligibility of company.", e, logMap);
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/eligibility/EligibilityRule.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/eligibility/EligibilityRule.java
@@ -1,0 +1,8 @@
+package uk.gov.companieshouse.registeredemailaddressapi.eligibility;
+
+import uk.gov.companieshouse.registeredemailaddressapi.exception.EligibilityException;
+import uk.gov.companieshouse.registeredemailaddressapi.exception.ServiceException;
+
+public interface EligibilityRule<T> {
+    void validate(T input) throws EligibilityException, ServiceException;
+}

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/eligibility/EligibilityStatusCode.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/eligibility/EligibilityStatusCode.java
@@ -1,0 +1,8 @@
+package uk.gov.companieshouse.registeredemailaddressapi.eligibility;
+
+public enum EligibilityStatusCode {
+    INVALID_COMPANY_STATUS,
+    INVALID_COMPANY_TYPE,
+    COMPANY_NOT_FOUND,
+    COMPANY_VALID_FOR_SERVICE
+}

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/eligibility/impl/CompanyStatusValidation.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/eligibility/impl/CompanyStatusValidation.java
@@ -1,0 +1,30 @@
+package uk.gov.companieshouse.registeredemailaddressapi.eligibility.impl;
+
+import java.util.Set;
+
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.EligibilityRule;
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.EligibilityStatusCode;
+import uk.gov.companieshouse.registeredemailaddressapi.exception.EligibilityException;
+import uk.gov.companieshouse.registeredemailaddressapi.utils.ApiLogger;
+
+public class CompanyStatusValidation implements EligibilityRule<CompanyProfileApi> {
+
+    private final Set<String> allowedStatuses;
+
+    public CompanyStatusValidation(Set<String> allowedStatuses) {
+        this.allowedStatuses = allowedStatuses;
+    }
+
+    @Override
+    public void validate(CompanyProfileApi profileToValidate) throws EligibilityException {
+        ApiLogger.info(String.format("Validating Company Status for: %s", profileToValidate.getCompanyNumber()));
+        var status = profileToValidate.getCompanyStatus();
+
+        if (!allowedStatuses.contains(status)) {
+            ApiLogger.info(String.format("Company Status validation failed for: %s", profileToValidate.getCompanyNumber()));
+            throw new EligibilityException(EligibilityStatusCode.INVALID_COMPANY_STATUS);
+        }
+        ApiLogger.info(String.format("Company Status validation passed for: %s", profileToValidate.getCompanyNumber()));
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/eligibility/impl/CompanyTypeValidation.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/eligibility/impl/CompanyTypeValidation.java
@@ -1,0 +1,33 @@
+package uk.gov.companieshouse.registeredemailaddressapi.eligibility.impl;
+
+import java.util.HashMap;
+import java.util.Set;
+
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.EligibilityRule;
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.EligibilityStatusCode;
+import uk.gov.companieshouse.registeredemailaddressapi.exception.EligibilityException;
+import uk.gov.companieshouse.registeredemailaddressapi.utils.ApiLogger;
+
+public class CompanyTypeValidation implements EligibilityRule<CompanyProfileApi> {
+
+    private final Set<String> companyTypes;
+
+    public CompanyTypeValidation(Set<String> companyTypes) {
+        this.companyTypes = companyTypes;
+    }
+
+    @Override
+    public void validate(CompanyProfileApi profileToValidate) throws EligibilityException {
+        var logMap = new HashMap<String, Object>();
+        logMap.put("companyProfile", profileToValidate);
+        ApiLogger.info(String.format("Validating Company Type Should Use for: %s", profileToValidate.getCompanyNumber()), logMap);
+
+        if (!companyTypes.contains(profileToValidate.getType())) {
+            ApiLogger.info(String.format("Company Type validation Should Use failed for: %s", profileToValidate.getCompanyNumber()), logMap);
+            throw new EligibilityException(EligibilityStatusCode.INVALID_COMPANY_TYPE);
+        }
+
+        ApiLogger.info(String.format("Company Type validation Should Use passed for: %s", profileToValidate.getCompanyNumber()), logMap);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/exception/CompanyNotFoundException.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/exception/CompanyNotFoundException.java
@@ -1,0 +1,4 @@
+package uk.gov.companieshouse.registeredemailaddressapi.exception;
+
+public class CompanyNotFoundException extends Exception{
+}

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/exception/EligibilityException.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/exception/EligibilityException.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.registeredemailaddressapi.exception;
+
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.EligibilityStatusCode;
+
+public class EligibilityException extends Exception {
+    private final EligibilityStatusCode eligibilityStatusCode;
+
+    public EligibilityException(EligibilityStatusCode eligibilityStatusCode) {
+        this.eligibilityStatusCode = eligibilityStatusCode;
+    }
+
+    public EligibilityStatusCode getEligibilityStatusCode() {
+        return eligibilityStatusCode;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/model/response/CompanyValidationResponse.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/model/response/CompanyValidationResponse.java
@@ -1,0 +1,26 @@
+package uk.gov.companieshouse.registeredemailaddressapi.model.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.EligibilityStatusCode;
+
+public class CompanyValidationResponse {
+
+    @JsonProperty("eligibility_status_code")
+    private EligibilityStatusCode eligibilityStatusCode;
+
+    public CompanyValidationResponse() {
+    }
+
+    public CompanyValidationResponse(EligibilityStatusCode eligibilityStatusCode) {
+        this.eligibilityStatusCode = eligibilityStatusCode;
+    }
+
+    public EligibilityStatusCode getEligibilityStatusCode() {
+        return eligibilityStatusCode;
+    }
+
+    public void setEligibilityStatusCode(EligibilityStatusCode eligibilityStatusCode) {
+        this.eligibilityStatusCode = eligibilityStatusCode;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/service/CompanyProfileService.java
@@ -1,0 +1,44 @@
+package uk.gov.companieshouse.registeredemailaddressapi.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.registeredemailaddressapi.client.ApiClientService;
+import uk.gov.companieshouse.registeredemailaddressapi.exception.CompanyNotFoundException;
+import uk.gov.companieshouse.registeredemailaddressapi.exception.ServiceException;
+
+@Service
+public class CompanyProfileService {
+
+    private static final String EXCEPTION_MESSAGE = "Error Retrieving Company Profile for company number %s";
+    private static final String EXCEPTION_MESSAGE_WITH_HTTP_CODE = EXCEPTION_MESSAGE + ", http status code %s";
+
+    private final ApiClientService apiClientService;
+
+    @Autowired
+    public CompanyProfileService(ApiClientService apiClientService) {
+        this.apiClientService = apiClientService;
+    }
+
+    public CompanyProfileApi getCompanyProfile(String companyNumber) throws ServiceException, CompanyNotFoundException {
+        try {
+            var uri = "/company/" + companyNumber;
+            return apiClientService.getApiKeyAuthenticatedClient().company().get(uri).execute().getData();
+        } catch (URIValidationException e) {
+            throw new ServiceException(String.format(EXCEPTION_MESSAGE, companyNumber), e);
+        } catch (ApiErrorResponseException e) {
+            if (HttpStatus.NOT_FOUND.value() == e.getStatusCode()) {
+                throw new CompanyNotFoundException();
+            }
+            var message = String.format(
+                    EXCEPTION_MESSAGE_WITH_HTTP_CODE,
+                    companyNumber,
+                    e.getStatusCode());
+            throw new ServiceException(message, e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/service/EligibilityService.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/service/EligibilityService.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.registeredemailaddressapi.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.EligibilityRule;
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.EligibilityStatusCode;
+import uk.gov.companieshouse.registeredemailaddressapi.exception.EligibilityException;
+import uk.gov.companieshouse.registeredemailaddressapi.exception.ServiceException;
+import uk.gov.companieshouse.registeredemailaddressapi.model.response.CompanyValidationResponse;
+import uk.gov.companieshouse.registeredemailaddressapi.utils.ApiLogger;
+
+@Service
+public class EligibilityService {
+
+    private final List<EligibilityRule<CompanyProfileApi>> eligibilityRules;
+
+    @Autowired
+    public EligibilityService(@Qualifier("rea-update-eligibility-rules")
+                                                    List<EligibilityRule<CompanyProfileApi>> eligibilityRules){
+        this.eligibilityRules = eligibilityRules;
+    }
+
+    public CompanyValidationResponse checkCompanyEligibility(CompanyProfileApi companyProfile) throws ServiceException {
+        var response = new CompanyValidationResponse();
+        try {
+            for (EligibilityRule<CompanyProfileApi> eligibilityRule : eligibilityRules) {
+                eligibilityRule.validate(companyProfile);
+            }
+        } catch (EligibilityException e) {
+            ApiLogger.info(String.format("Company %s ineligible to use the service because %s",  companyProfile.getCompanyNumber(), e.getEligibilityStatusCode()));
+            response.setEligibilityStatusCode(e.getEligibilityStatusCode());
+            return response;
+        }
+        response.setEligibilityStatusCode(EligibilityStatusCode.COMPANY_VALID_FOR_SERVICE);
+        return response;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/controller/EligibilityControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/controller/EligibilityControllerTest.java
@@ -1,0 +1,84 @@
+package uk.gov.companieshouse.registeredemailaddressapi.unit.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.registeredemailaddressapi.controller.EligibilityController;
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.EligibilityStatusCode;
+import uk.gov.companieshouse.registeredemailaddressapi.exception.CompanyNotFoundException;
+import uk.gov.companieshouse.registeredemailaddressapi.exception.ServiceException;
+import uk.gov.companieshouse.registeredemailaddressapi.model.response.CompanyValidationResponse;
+import uk.gov.companieshouse.registeredemailaddressapi.service.CompanyProfileService;
+import uk.gov.companieshouse.registeredemailaddressapi.service.EligibilityService;
+
+@ExtendWith(MockitoExtension.class)
+class EligibilityControllerTest {
+
+    private static final String COMPANY_NUMBER = "11111111";
+    private static final String ERIC_REQUEST_ID = "XaBcDeF12345";
+
+    @Mock
+    private CompanyProfileService companyProfileService;
+
+    @Mock
+    private EligibilityService eligibilityService;
+
+    @InjectMocks
+    private EligibilityController eligibilityController;
+
+    @Test
+    void testSuccessfulGetEligibility() throws ServiceException, CompanyNotFoundException {
+        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
+        companyProfileApi.setCompanyStatus("AcceptValue");
+        when(companyProfileService.getCompanyProfile(COMPANY_NUMBER)).thenReturn(companyProfileApi);
+        CompanyValidationResponse companyValidationResponse = new CompanyValidationResponse();
+        companyValidationResponse.setEligibilityStatusCode(EligibilityStatusCode.COMPANY_VALID_FOR_SERVICE);
+        when(eligibilityService.checkCompanyEligibility(companyProfileApi)).thenReturn(companyValidationResponse);
+        ResponseEntity<CompanyValidationResponse> response = eligibilityController.getEligibility(COMPANY_NUMBER, ERIC_REQUEST_ID);
+        assertEquals(200, response.getStatusCodeValue());
+    }
+
+    @Test
+    void testFailedGetEligibility() throws ServiceException, CompanyNotFoundException {
+        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
+        companyProfileApi.setCompanyStatus("FailureValue");
+        when(companyProfileService.getCompanyProfile(COMPANY_NUMBER)).thenReturn(companyProfileApi);
+        CompanyValidationResponse companyValidationResponse = new CompanyValidationResponse();
+        companyValidationResponse.setEligibilityStatusCode(EligibilityStatusCode.INVALID_COMPANY_STATUS);
+        when(eligibilityService.checkCompanyEligibility(companyProfileApi)).thenReturn(companyValidationResponse);
+        ResponseEntity<CompanyValidationResponse> response = eligibilityController.getEligibility(COMPANY_NUMBER, ERIC_REQUEST_ID);
+        assertEquals(400, response.getStatusCodeValue());
+    }
+
+    @Test
+    void testServiceExceptionGetEligibility() throws ServiceException, CompanyNotFoundException {
+        when(companyProfileService.getCompanyProfile(COMPANY_NUMBER)).thenThrow(new ServiceException("", new Exception()));
+        ResponseEntity<CompanyValidationResponse> response = eligibilityController.getEligibility(COMPANY_NUMBER, ERIC_REQUEST_ID);
+        assertEquals(500, response.getStatusCodeValue());
+    }
+
+    @Test
+    void testUncheckedExceptionGetEligibility() throws ServiceException, CompanyNotFoundException {
+        when(companyProfileService.getCompanyProfile(COMPANY_NUMBER)).thenThrow(new RuntimeException("runtime exception"));
+        ResponseEntity<CompanyValidationResponse> response = eligibilityController.getEligibility(COMPANY_NUMBER, ERIC_REQUEST_ID);
+        assertEquals(500, response.getStatusCodeValue());
+    }
+
+    @Test
+    void testCompanyNotFound() throws ServiceException, CompanyNotFoundException {
+        when(companyProfileService.getCompanyProfile(COMPANY_NUMBER)).thenThrow(new CompanyNotFoundException());
+        ResponseEntity<CompanyValidationResponse> response = eligibilityController.getEligibility(COMPANY_NUMBER, ERIC_REQUEST_ID);
+        assertEquals(400, response.getStatusCodeValue());
+        assertNotNull(response.getBody());
+        assertEquals(EligibilityStatusCode.COMPANY_NOT_FOUND, response.getBody().getEligibilityStatusCode());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/eligibility/impl/CompanyStatusValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/eligibility/impl/CompanyStatusValidationTest.java
@@ -1,0 +1,58 @@
+package uk.gov.companieshouse.registeredemailaddressapi.unit.eligibility.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.EligibilityStatusCode;
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.impl.CompanyStatusValidation;
+import uk.gov.companieshouse.registeredemailaddressapi.exception.EligibilityException;
+
+class CompanyStatusValidationTest {
+
+    private static final String ALLOWED_VALUE = "AllowedStatus";
+    private static final Set<String> ALLOWED_LIST = Collections.singleton(ALLOWED_VALUE);
+
+    private CompanyStatusValidation companyStatusValidation;
+
+    @BeforeEach
+    void init() {
+        companyStatusValidation = new CompanyStatusValidation(ALLOWED_LIST);
+    }
+
+    @Test
+    void validateDoesNotThrowOnAllowedValue() {
+        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
+        companyProfileApi.setCompanyStatus(ALLOWED_VALUE);
+
+        assertDoesNotThrow(() -> companyStatusValidation.validate(companyProfileApi));
+    }
+
+    @Test
+    void validateThrowsOnDisallowedValue() {
+        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
+        companyProfileApi.setCompanyStatus("Disallowed_Value");
+
+        var ex = assertThrows(EligibilityException.class, () ->
+                companyStatusValidation.validate(companyProfileApi));
+
+        assertEquals(EligibilityStatusCode.INVALID_COMPANY_STATUS, ex.getEligibilityStatusCode());
+    }
+
+    @Test
+    void validateThrowsOnNullStatus() {
+        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
+        companyProfileApi.setCompanyStatus(null);
+
+        var ex = assertThrows(EligibilityException.class, () -> companyStatusValidation.validate(companyProfileApi));
+
+        assertEquals(EligibilityStatusCode.INVALID_COMPANY_STATUS, ex.getEligibilityStatusCode());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/eligibility/impl/CompanyTypeValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/eligibility/impl/CompanyTypeValidationTest.java
@@ -1,0 +1,57 @@
+package uk.gov.companieshouse.registeredemailaddressapi.unit.eligibility.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.EligibilityStatusCode;
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.impl.CompanyTypeValidation;
+import uk.gov.companieshouse.registeredemailaddressapi.exception.EligibilityException;
+
+class CompanyTypeValidationTest {
+
+    private static final String ALLOWED_VALUE = "Allowed_Type";
+    private static final Set<String> ALLOWED_LIST = Collections.singleton(ALLOWED_VALUE);
+
+    private CompanyTypeValidation companyTypeValidation;
+
+    @BeforeEach
+    void init() {
+        companyTypeValidation = new CompanyTypeValidation(ALLOWED_LIST);
+    }
+
+    @Test
+    void validateThrowsOnInvalidType() {
+        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
+        companyProfileApi.setType("Invalid_Type");
+
+        var ex = assertThrows(EligibilityException.class, () -> companyTypeValidation.validate(companyProfileApi));
+
+        assertEquals(EligibilityStatusCode.INVALID_COMPANY_TYPE, ex.getEligibilityStatusCode());
+    }
+
+    @Test
+    void validateDoesNotThrowOnValidType() {
+        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
+        companyProfileApi.setType(ALLOWED_VALUE);
+
+        assertDoesNotThrow(() -> companyTypeValidation.validate(companyProfileApi));
+    }
+
+    @Test
+    void validateThrowsOnNullType() {
+        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
+        companyProfileApi.setType(null);
+
+        var ex = assertThrows(EligibilityException.class, () -> companyTypeValidation.validate(companyProfileApi));
+
+        assertEquals(EligibilityStatusCode.INVALID_COMPANY_TYPE, ex.getEligibilityStatusCode());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/exception/ServiceExceptionTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/exception/ServiceExceptionTest.java
@@ -1,16 +1,12 @@
 package uk.gov.companieshouse.registeredemailaddressapi.unit.exception;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import uk.gov.companieshouse.registeredemailaddressapi.exception.ServiceException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.when;
-import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.ERIC_REQUEST_ID_KEY;
+import uk.gov.companieshouse.registeredemailaddressapi.exception.ServiceException;
 
 @ExtendWith(MockitoExtension.class)
 class ServiceExceptionTest {

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/CompanyProfileServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/CompanyProfileServiceTest.java
@@ -1,0 +1,104 @@
+package uk.gov.companieshouse.registeredemailaddressapi.unit.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpResponseException;
+
+import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.company.CompanyResourceHandler;
+import uk.gov.companieshouse.api.handler.company.request.CompanyGet;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.registeredemailaddressapi.client.ApiClientService;
+import uk.gov.companieshouse.registeredemailaddressapi.exception.CompanyNotFoundException;
+import uk.gov.companieshouse.registeredemailaddressapi.exception.ServiceException;
+import uk.gov.companieshouse.registeredemailaddressapi.service.CompanyProfileService;
+
+@ExtendWith(MockitoExtension.class)
+class CompanyProfileServiceTest {
+
+    private static final String COMPANY_NUMBER = "12345678";
+    @Mock
+    private ApiClientService apiClientService;
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private CompanyResourceHandler companyResourceHandler;
+
+    @Mock
+    private CompanyGet companyGet;
+
+    @Mock
+    private ApiResponse<CompanyProfileApi> apiResponse;
+
+    @InjectMocks
+    private CompanyProfileService companyProfileService;
+
+    @Test
+    void getCompanyProfile() throws ServiceException, ApiErrorResponseException, URIValidationException, CompanyNotFoundException {
+        CompanyProfileApi companyProfile = new CompanyProfileApi();
+        companyProfile.setCompanyName("COMPANY NAME");
+
+        when(apiClientService.getApiKeyAuthenticatedClient()).thenReturn(apiClient);
+        when(apiClient.company()).thenReturn(companyResourceHandler);
+        when(companyResourceHandler.get("/company/" + COMPANY_NUMBER)).thenReturn(companyGet);
+        when(companyGet.execute()).thenReturn(apiResponse);
+        when(apiResponse.getData()).thenReturn(companyProfile);
+
+        var response = companyProfileService.getCompanyProfile(COMPANY_NUMBER);
+
+        assertEquals(companyProfile, response);
+    }
+
+    @Test
+    void getCompanyProfileURIValidationException() throws ApiErrorResponseException, URIValidationException {
+        when(apiClientService.getApiKeyAuthenticatedClient()).thenReturn(apiClient);
+        when(apiClient.company()).thenReturn(companyResourceHandler);
+        when(companyResourceHandler.get("/company/" + COMPANY_NUMBER)).thenReturn(companyGet);
+        when(companyGet.execute()).thenThrow(new URIValidationException("ERROR"));
+
+        ServiceException se = assertThrows(ServiceException.class, () -> companyProfileService.getCompanyProfile(COMPANY_NUMBER));
+        assertTrue(se.getMessage().contains(COMPANY_NUMBER));
+    }
+
+    @Test
+    void getCompanyProfileApiErrorResponse() throws ApiErrorResponseException, URIValidationException {
+        when(apiClientService.getApiKeyAuthenticatedClient()).thenReturn(apiClient);
+        when(apiClient.company()).thenReturn(companyResourceHandler);
+        when(companyResourceHandler.get("/company/" + COMPANY_NUMBER)).thenReturn(companyGet);
+        when(companyGet.execute()).thenThrow(ApiErrorResponseException.fromIOException(new IOException("ERROR")));
+
+        ServiceException se = assertThrows(ServiceException.class, () -> companyProfileService.getCompanyProfile(COMPANY_NUMBER));
+        assertTrue(se.getMessage().contains(COMPANY_NUMBER));
+        assertTrue(se.getMessage().contains("500"));
+    }
+
+    @Test
+    void getCompanyProfileApiCompanyNotFoundResponse() throws ApiErrorResponseException, URIValidationException {
+        when(apiClientService.getApiKeyAuthenticatedClient()).thenReturn(apiClient);
+        when(apiClient.company()).thenReturn(companyResourceHandler);
+        when(companyResourceHandler.get("/company/" + COMPANY_NUMBER)).thenReturn(companyGet);
+
+        HttpResponseException httpResponseException =
+                new HttpResponseException.Builder(404, "test", new HttpHeaders()).build();
+        when(companyGet.execute()).thenThrow(ApiErrorResponseException.fromHttpResponseException(httpResponseException));
+
+        assertThrows(CompanyNotFoundException.class, () -> companyProfileService.getCompanyProfile(COMPANY_NUMBER));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/EligibilityServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/EligibilityServiceTest.java
@@ -1,0 +1,70 @@
+package uk.gov.companieshouse.registeredemailaddressapi.unit.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doThrow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.EligibilityRule;
+import uk.gov.companieshouse.registeredemailaddressapi.eligibility.EligibilityStatusCode;
+import uk.gov.companieshouse.registeredemailaddressapi.exception.EligibilityException;
+import uk.gov.companieshouse.registeredemailaddressapi.exception.ServiceException;
+import uk.gov.companieshouse.registeredemailaddressapi.model.response.CompanyValidationResponse;
+import uk.gov.companieshouse.registeredemailaddressapi.service.EligibilityService;
+
+@ExtendWith(MockitoExtension.class)
+class EligibilityServiceTest {
+
+
+    private List<EligibilityRule<CompanyProfileApi>> eligibilityRules;
+
+    @Mock EligibilityRule<CompanyProfileApi> eligibilityRule;
+
+    private EligibilityService eligibilityService;
+
+    @BeforeEach
+    void init() {
+        eligibilityRules = new ArrayList<>();
+        eligibilityRules.add(eligibilityRule);
+        eligibilityService = new EligibilityService(eligibilityRules);
+    }
+
+    @Test
+    void tesWithNoErrors() throws ServiceException {
+        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
+        companyProfileApi.setCompanyStatus("AcceptValue");
+        var responseBody = eligibilityService.checkCompanyEligibility(companyProfileApi);
+        assertNotNull(responseBody);
+        assertEquals(EligibilityStatusCode.COMPANY_VALID_FOR_SERVICE, responseBody.getEligibilityStatusCode());
+    }
+
+    @Test
+    void testInvalidCompanyStatus() throws EligibilityException, ServiceException {
+        var responseBody = getValidationErrorResponse(EligibilityStatusCode.INVALID_COMPANY_STATUS);
+        assertNotNull(responseBody);
+        assertEquals(EligibilityStatusCode.INVALID_COMPANY_STATUS, responseBody.getEligibilityStatusCode());
+    }
+
+    @Test
+    void testInvalidCompanyType() throws EligibilityException, ServiceException {
+        var responseBody = getValidationErrorResponse(EligibilityStatusCode.INVALID_COMPANY_TYPE);
+        assertNotNull(responseBody);
+        assertEquals(EligibilityStatusCode.INVALID_COMPANY_TYPE, responseBody.getEligibilityStatusCode());
+
+    }
+
+    private CompanyValidationResponse getValidationErrorResponse(EligibilityStatusCode reason) throws EligibilityException, ServiceException {
+        CompanyProfileApi companyProfileApi = new CompanyProfileApi();
+        doThrow(new EligibilityException(reason)).when(eligibilityRule).validate(companyProfileApi);
+        return eligibilityService.checkCompanyEligibility(companyProfileApi);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/RegisteredEmailAddressFilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/RegisteredEmailAddressFilingServiceTest.java
@@ -1,5 +1,22 @@
 package uk.gov.companieshouse.registeredemailaddressapi.unit.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.ACCEPT_EMAIL_STATEMENT;
+import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.COMPANY_NUMBER;
+import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.FILING_KIND;
+import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.REGISTERED_EMAIL_ADDRESS;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -8,6 +25,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.util.ReflectionTestUtils;
+
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
@@ -16,22 +34,11 @@ import uk.gov.companieshouse.registeredemailaddressapi.integration.utils.Helper;
 import uk.gov.companieshouse.registeredemailaddressapi.mapper.RegisteredEmailAddressMapper;
 import uk.gov.companieshouse.registeredemailaddressapi.model.dao.RegisteredEmailAddressDAO;
 import uk.gov.companieshouse.registeredemailaddressapi.model.dao.RegisteredEmailAddressData;
-import uk.gov.companieshouse.registeredemailaddressapi.model.dto.RegisteredEmailAddressDTO;
 import uk.gov.companieshouse.registeredemailaddressapi.model.dto.RegisteredEmailAddressResponseDTO;
 import uk.gov.companieshouse.registeredemailaddressapi.repository.RegisteredEmailAddressRepository;
 import uk.gov.companieshouse.registeredemailaddressapi.service.RegisteredEmailAddressFilingService;
 import uk.gov.companieshouse.registeredemailaddressapi.service.RegisteredEmailAddressService;
 import uk.gov.companieshouse.registeredemailaddressapi.service.TransactionService;
-
-import java.io.IOException;
-import java.time.LocalDate;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.function.Supplier;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.*;
 
 @ExtendWith(MockitoExtension.class)
 class RegisteredEmailAddressFilingServiceTest {
@@ -100,7 +107,7 @@ class RegisteredEmailAddressFilingServiceTest {
         verify(localDateSupplier, times(1)).get();
         assertEquals(FILING_KIND, registeredEmailAddressFiling.getKind());
         assertEquals(REA_FILING_DESCRIPTION_IDENTIFIER, registeredEmailAddressFiling.getDescriptionIdentifier());
-        assertEquals("Registered Email Address Filing update statement made 26 March 2023", registeredEmailAddressFiling.getDescription());   
+        assertEquals("Registered Email Address Filing update statement made 26 March 2023", registeredEmailAddressFiling.getDescription());
         assertEquals(TEST_EMAIL, registeredEmailAddressFiling.getData().get(REGISTERED_EMAIL_ADDRESS));
         assertEquals(TEST_COMPANY_NUMBER, registeredEmailAddressFiling.getData().get(COMPANY_NUMBER));
         assertEquals(true, registeredEmailAddressFiling.getData().get(ACCEPT_EMAIL_STATEMENT));
@@ -126,12 +133,6 @@ class RegisteredEmailAddressFilingServiceTest {
         transaction.setId(TRANSACTION_ID);
         transaction.setCompanyNumber(TEST_COMPANY_NUMBER);
         return transaction;
-    }
-
-    private RegisteredEmailAddressDTO buildRegisteredEmailAddressDTO() {
-        RegisteredEmailAddressDTO registeredEmailAddressDTO = new RegisteredEmailAddressDTO();
-        registeredEmailAddressDTO.setRegisteredEmailAddress(TEST_EMAIL);
-        return registeredEmailAddressDTO;
     }
 
     private RegisteredEmailAddressDAO buildRegisteredEmailAddressDAO() {

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/RegisteredEmailAddressServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/RegisteredEmailAddressServiceTest.java
@@ -254,7 +254,7 @@ class RegisteredEmailAddressServiceTest {
             fail();
         } catch (Exception e) {
             assertEquals(ServiceException.class, e.getClass());
-            assertEquals(e.getMessage(), format("Transaction %s invalid", null));
+            assertEquals(e.getMessage(), format("Transaction %s invalid", "null"));
         }
     }
 


### PR DESCRIPTION
Work done:
- Implemented the eligibility endpoint using C-A-P from CS service
- Unit tests of eligibility endpoint (existing integration tests fail in local environment)
- Integration tests of eligibility endpoint in CHS Dev Env using Postman, all AC pass
- Fixed a few Eclipse compiler warnings