### PR TITLE
Validate url params company num and txn id [ECCT-853]

### DIFF
--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/controller/EligibilityController.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/controller/EligibilityController.java
@@ -1,12 +1,16 @@
 package uk.gov.companieshouse.registeredemailaddressapi.controller;
 
+import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.COMPANY_NUMBER_REGEX;
 import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.ERIC_REQUEST_ID_KEY;
 
 import java.util.HashMap;
 
+import javax.validation.constraints.Pattern;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -20,6 +24,7 @@ import uk.gov.companieshouse.registeredemailaddressapi.service.EligibilityServic
 import uk.gov.companieshouse.registeredemailaddressapi.utils.ApiLogger;
 
 @RestController
+@Validated
 public class EligibilityController {
 
     @Autowired
@@ -29,7 +34,9 @@ public class EligibilityController {
     private EligibilityService eligibilityService;
 
     @GetMapping("/registered-email-address/company/{company-number}/eligibility")
-    public ResponseEntity<CompanyValidationResponse> getEligibility(@PathVariable("company-number") String companyNumber,
+    public ResponseEntity<CompanyValidationResponse> getEligibility(
+            @PathVariable("company-number") @Pattern(regexp = COMPANY_NUMBER_REGEX,
+                message = "Invalid company number") String companyNumber,
             @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId) {
 
         var logMap = new HashMap<String, Object>();

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/exception/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/exception/GlobalExceptionHandler.java
@@ -4,7 +4,10 @@ import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.ER
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import javax.validation.ConstraintViolationException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.owasp.encoder.Encode;
@@ -73,6 +76,18 @@ public class GlobalExceptionHandler {
         logException(ex, webRequest);
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<Object> constraintViolationException(ConstraintViolationException ex, WebRequest webRequest) {
+        logException(ex, webRequest);
+        List<String> errorsList = new ArrayList<>();
+
+        ex.getConstraintViolations().forEach(cv -> errorsList.add(cv.getMessage()));
+
+        Map<String, List<String>> errors = new HashMap<>();
+        errors.put("errors", errorsList);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/interceptor/TransactionInterceptor.java
@@ -14,6 +14,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.*;
@@ -41,6 +42,11 @@ public class TransactionInterceptor implements HandlerInterceptor {
         var logMap = new HashMap<String, Object>();
         logMap.put(TRANSACTION_ID_KEY, transactionId);
         String reqId = request.getHeader(ERIC_REQUEST_ID_KEY);
+        if (!Pattern.matches(TRANSACTION_ID_REGEX,transactionId)){
+            ApiLogger.debugContext(reqId, "Transaction id did not pass validation", logMap);
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return false; // TODO set body
+        }
         try {
             ApiLogger.debugContext(reqId, "Getting transaction for request.", logMap);
 

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/interceptor/TransactionInterceptor.java
@@ -5,6 +5,9 @@ import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import uk.gov.companieshouse.registeredemailaddressapi.service.TransactionService;
 import uk.gov.companieshouse.registeredemailaddressapi.utils.ApiLogger;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
@@ -43,9 +46,13 @@ public class TransactionInterceptor implements HandlerInterceptor {
         logMap.put(TRANSACTION_ID_KEY, transactionId);
         String reqId = request.getHeader(ERIC_REQUEST_ID_KEY);
         if (!Pattern.matches(TRANSACTION_ID_REGEX,transactionId)){
-            ApiLogger.debugContext(reqId, "Transaction id did not pass validation", logMap);
+            ApiLogger.debugContext(reqId, "Invalid transaction id", logMap);
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            return false; // TODO set body
+            var errorsList = Map.of("errors", Map.of("error", "Invalid transaction id"));
+            response.setContentType("application/json");
+            ObjectMapper objectMapper = new ObjectMapper();
+            response.getWriter().write(objectMapper.writeValueAsString(errorsList));
+            return false;
         }
         try {
             ApiLogger.debugContext(reqId, "Getting transaction for request.", logMap);

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/interceptor/TransactionInterceptor.java
@@ -50,7 +50,7 @@ public class TransactionInterceptor implements HandlerInterceptor {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             var errorsList = Map.of("errors", Map.of("error", "Invalid transaction id"));
             response.setContentType("application/json");
-            ObjectMapper objectMapper = new ObjectMapper();
+            var objectMapper = new ObjectMapper();
             response.getWriter().write(objectMapper.writeValueAsString(errorsList));
             return false;
         }

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/interceptor/TransactionInterceptor.java
@@ -1,5 +1,19 @@
 package uk.gov.companieshouse.registeredemailaddressapi.interceptor;
 
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.ERIC_REQUEST_ID_KEY;
+import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.TRANSACTION_ID_KEY;
+import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.TRANSACTION_ID_REGEX;
+import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.TRANSACTION_KEY;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
@@ -12,16 +26,6 @@ import uk.gov.companieshouse.registeredemailaddressapi.service.TransactionServic
 import uk.gov.companieshouse.registeredemailaddressapi.utils.ApiLogger;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Pattern;
-
-import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
-import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.*;
-
 /**
  * Retrieves the transaction data and sets it into the request.
  */
@@ -29,6 +33,7 @@ import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.*;
 public class TransactionInterceptor implements HandlerInterceptor {
 
     private final TransactionService transactionService;
+    private static final Pattern TRANSACTION_ID_PATTERN = Pattern.compile(TRANSACTION_ID_REGEX);
 
     @Autowired
     public TransactionInterceptor(TransactionService transactionService) {
@@ -45,8 +50,10 @@ public class TransactionInterceptor implements HandlerInterceptor {
         var logMap = new HashMap<String, Object>();
         logMap.put(TRANSACTION_ID_KEY, transactionId);
         String reqId = request.getHeader(ERIC_REQUEST_ID_KEY);
-        if (!Pattern.matches(TRANSACTION_ID_REGEX,transactionId)){
+
+        if (!TRANSACTION_ID_PATTERN.matcher(transactionId).matches()) {
             ApiLogger.debugContext(reqId, "Invalid transaction id", logMap);
+
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             var errorsList = Map.of("errors", Map.of("error", "Invalid transaction id"));
             response.setContentType("application/json");
@@ -54,6 +61,7 @@ public class TransactionInterceptor implements HandlerInterceptor {
             response.getWriter().write(objectMapper.writeValueAsString(errorsList));
             return false;
         }
+
         try {
             ApiLogger.debugContext(reqId, "Getting transaction for request.", logMap);
 

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/utils/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/utils/Constants.java
@@ -40,4 +40,7 @@ public class Constants {
     // Utitity constants
     public static final String DATE_FORMATTER_PATTERN = "d MMMM yyyy";
 
+    // validation constants
+    public static final String COMPANY_NUMBER_REGEX = "\\w{8}"; // 8 chars (alphanumeric)
+    public static final String TRANSACTION_ID_REGEX = "[0-9-]{20}"; // 20 chars (digits and -)
 }

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/EligibilityControllerEmailMockingIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/EligibilityControllerEmailMockingIntegrationTest.java
@@ -61,5 +61,19 @@ class EligibilityControllerEmailMockingIntegrationTest {
                 .andExpect(content().json("{\"eligibility_status_code\":\"INVALID_NO_REGISTERED_EMAIL_ADDRESS_EXISTS\"}"));
     }
 
+    @Test
+    void EligibilityEndpointInvalidCompanyNumberTest() throws Exception {
+
+        final String companyNumber = "12345678999"; // too long
+        CompanyProfileApi companyProfileApi = HELPER.generateCompanyProfileApi(companyNumber);
+        given(companyProfileService.getCompanyProfile(companyNumber)).willReturn(companyProfileApi);
+
+        this.mvc.perform(get("/registered-email-address/company/"+companyNumber+"/eligibility")
+                .contentType("application/json").header("ERIC-Identity", "123")
+                .header("X-Request-Id", "123456")
+                .header("ERIC-Authorised-Token-Permissions", "company_number="+companyNumber+" company_rea=update"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().json("{\"errors\":[\"Invalid company number\"]}"));
+    }
 
 }

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/RegisteredEmailAddressControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/RegisteredEmailAddressControllerIntegrationTest.java
@@ -256,7 +256,7 @@ class RegisteredEmailAddressControllerIntegrationTest {
 
 
         String email = "UpdateTest@Test.com";
-        String transactionId = "xxxxx-xxxxx-xxxxx";
+        String transactionId = "0-0-0-0-0-0-0-0-0-0-"; // passes validation but will never be generated
         RegisteredEmailAddressDTO registeredEmailAddressDTO = helper.generateRegisteredEmailAddressDTO(email);
         RegisteredEmailAddressDAO registeredEmailAddressDAO = helper
                 .generateRegisteredEmailAddressDAO(email, transactionId);

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/utils/Helper.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/utils/Helper.java
@@ -22,9 +22,9 @@ public class Helper {
     public Transaction generateTransaction(){
         Transaction transaction = new Transaction();
         Random random = new Random(Integer.MAX_VALUE);
-        String rand = String.format("%018d", random.nextInt());
-        String[] tranId = rand.split("(?<=\\G.{6})");
-        transaction.setId(String.join("-", tranId));
+        String rand = String.format("%018d", random.nextInt()); // 18 digit int
+        String[] tranId = rand.split("(?<=\\G.{6})"); // split into groups of 6
+        transaction.setId(String.join("-", tranId)); // join with -
         return transaction;
     }
 

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/utils/Helper.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/utils/Helper.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.registeredemailaddressapi.integration.utils;
 
+import java.util.Random;
 import java.util.UUID;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -20,8 +21,10 @@ public class Helper {
 
     public Transaction generateTransaction(){
         Transaction transaction = new Transaction();
-        String id = UUID.randomUUID().toString();
-        transaction.setId(id);
+        Random random = new Random(Integer.MAX_VALUE);
+        String rand = String.format("%018d", random.nextInt());
+        String[] tranId = rand.split("(?<=\\G.{6})");
+        transaction.setId(String.join("-", tranId));
         return transaction;
     }
 

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/interceptor/TransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/interceptor/TransactionInterceptorTest.java
@@ -71,6 +71,7 @@ class TransactionInterceptorTest {
 
         assertFalse(transactionInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler));
         assertEquals(HttpServletResponse.SC_BAD_REQUEST,  mockHttpServletResponse.getStatus());
+        assertEquals("{\"errors\":{\"error\":\"Invalid transaction id\"}}", mockHttpServletResponse.getContentAsString());
     }
 
     @Test
@@ -86,6 +87,7 @@ class TransactionInterceptorTest {
 
         assertFalse(transactionInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler));
         assertEquals(HttpServletResponse.SC_BAD_REQUEST,  mockHttpServletResponse.getStatus());
+        assertEquals("{\"errors\":{\"error\":\"Invalid transaction id\"}}", mockHttpServletResponse.getContentAsString());
     }
 
     @Test


### PR DESCRIPTION
Adding validation for company num & txn id when passed as url params.
Used @validated annotation for company num, but txn id is used to call
out to another service in the interceptor before it hits the controller,
so validation for this was added in the interceptor instead.