### PR TITLE
Allow for auth with valid company number format by prefixing instead of suffixing

### DIFF
--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/service/MockEmailRetrieverImpl.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/service/MockEmailRetrieverImpl.java
@@ -13,22 +13,16 @@ import java.util.HashMap;
 @ConditionalOnExpression("'${env.name}'.equals('stagsbox') || '${env.name}'.equals('livesbox')")
 public class MockEmailRetrieverImpl implements PrivateDataRetrievalService {
 
-    private static final String TEST_COMPANY_PREFIX = "RE";
     private static final String MOCK_EMAIL = "mockexistingemail@companieshouse.gov.uk";
 
     @Override
     public RegisteredEmailAddressJson getRegisteredEmailAddress(String companyNumber) throws ServiceException {
 
         var logMap = new HashMap<String, Object>();
+        ApiLogger.info(format("Mocking Registered Email Address lookup for sandbox environment - returning mock email address for company number %s", companyNumber), logMap);
+        var registeredEmailAddressJson = new RegisteredEmailAddressJson();
+        registeredEmailAddressJson.setRegisteredEmailAddress(MOCK_EMAIL);
+        return registeredEmailAddressJson;
 
-        if (companyNumber.startsWith(TEST_COMPANY_PREFIX)) {
-            ApiLogger.info(format("Mocking Registered Email Address lookup for sandbox environment - returning mock email address for company number %s", companyNumber), logMap);
-            var registeredEmailAddressJson = new RegisteredEmailAddressJson();
-            registeredEmailAddressJson.setRegisteredEmailAddress(MOCK_EMAIL);
-            return registeredEmailAddressJson;
-        } else {
-            ApiLogger.info(format("Mocking Registered Email Address lookup for sandbox environment - returning no email address as company number %s does not start with %s", companyNumber, TEST_COMPANY_PREFIX), logMap);
-            return null;
-        }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/service/MockEmailRetrieverImpl.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/service/MockEmailRetrieverImpl.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 @ConditionalOnExpression("'${env.name}'.equals('stagsbox') || '${env.name}'.equals('livesbox')")
 public class MockEmailRetrieverImpl implements PrivateDataRetrievalService {
 
-    private static final String TEST_COMPANY_SUFFIX = "ERR";
+    private static final String TEST_COMPANY_PREFIX = "RE";
     private static final String MOCK_EMAIL = "mockexistingemail@companieshouse.gov.uk";
 
     @Override
@@ -21,13 +21,13 @@ public class MockEmailRetrieverImpl implements PrivateDataRetrievalService {
 
         var logMap = new HashMap<String, Object>();
 
-        if (companyNumber.endsWith(TEST_COMPANY_SUFFIX)) {
+        if (companyNumber.startsWith(TEST_COMPANY_PREFIX)) {
             ApiLogger.info(format("Mocking Registered Email Address lookup for sandbox environment - returning mock email address for company number %s", companyNumber), logMap);
             var registeredEmailAddressJson = new RegisteredEmailAddressJson();
             registeredEmailAddressJson.setRegisteredEmailAddress(MOCK_EMAIL);
             return registeredEmailAddressJson;
         } else {
-            ApiLogger.info(format("Mocking Registered Email Address lookup for sandbox environment - returning no email address as company number %s does not end with %s", companyNumber, TEST_COMPANY_SUFFIX), logMap);
+            ApiLogger.info(format("Mocking Registered Email Address lookup for sandbox environment - returning no email address as company number %s does not start with %s", companyNumber, TEST_COMPANY_PREFIX), logMap);
             return null;
         }
     }

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/EligibilityControllerEmailMockingIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/EligibilityControllerEmailMockingIntegrationTest.java
@@ -34,7 +34,7 @@ class EligibilityControllerEmailMockingIntegrationTest {
     @Test
     void EligibilityEndpointMockEmailResponseTest() throws Exception {
 
-        final String companyNumber = "12345ERR";
+        final String companyNumber = "RE123456";
         CompanyProfileApi companyProfileApi = HELPER.generateCompanyProfileApi(companyNumber);
         given(companyProfileService.getCompanyProfile(companyNumber)).willReturn(companyProfileApi);
 

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/EligibilityControllerEmailMockingIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/EligibilityControllerEmailMockingIntegrationTest.java
@@ -47,21 +47,6 @@ class EligibilityControllerEmailMockingIntegrationTest {
     }
 
     @Test
-    void EligibilityEndpointMockNullResponseTest() throws Exception {
-
-        final String companyNumber = "12345678";
-        CompanyProfileApi companyProfileApi = HELPER.generateCompanyProfileApi(companyNumber);
-        given(companyProfileService.getCompanyProfile(companyNumber)).willReturn(companyProfileApi);
-
-        this.mvc.perform(get("/registered-email-address/company/"+companyNumber+"/eligibility")
-                .contentType("application/json").header("ERIC-Identity", "123")
-                .header("X-Request-Id", "123456")
-                .header("ERIC-Authorised-Token-Permissions", "company_number="+companyNumber+" company_rea=update"))
-                .andExpect(status().isOk())
-                .andExpect(content().json("{\"eligibility_status_code\":\"INVALID_NO_REGISTERED_EMAIL_ADDRESS_EXISTS\"}"));
-    }
-
-    @Test
     void EligibilityEndpointInvalidCompanyNumberTest() throws Exception {
 
         final String companyNumber = "12345678999"; // too long

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/MockEmailRetrieverImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/MockEmailRetrieverImplTest.java
@@ -11,7 +11,6 @@ import uk.gov.companieshouse.registeredemailaddressapi.service.MockEmailRetrieve
 class MockEmailRetrieverImplTest {
 
     private static final String COMPANY_NUMBER = "12345678";
-    private static final String COMPANY_NUMBER_RE = "RE123456";
     private static final String COMPANY_EMAIL_MOCK = "mockexistingemail@companieshouse.gov.uk";
 
 
@@ -24,15 +23,8 @@ class MockEmailRetrieverImplTest {
         @Test
         void testMockEmailAddressForTestCompany() throws ServiceException {
 
-            RegisteredEmailAddressJson response = mockEmailRetrieverImpl.getRegisteredEmailAddress(COMPANY_NUMBER_RE);
-            assertEquals(COMPANY_EMAIL_MOCK, response.getRegisteredEmailAddress());
-        }
-
-        @Test
-        void testMockNullResponseForNonTestCompany() throws ServiceException {
-
             RegisteredEmailAddressJson response = mockEmailRetrieverImpl.getRegisteredEmailAddress(COMPANY_NUMBER);
-            assertNull(response);
+            assertEquals(COMPANY_EMAIL_MOCK, response.getRegisteredEmailAddress());
         }
     }
 }

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/MockEmailRetrieverImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/service/MockEmailRetrieverImplTest.java
@@ -11,7 +11,7 @@ import uk.gov.companieshouse.registeredemailaddressapi.service.MockEmailRetrieve
 class MockEmailRetrieverImplTest {
 
     private static final String COMPANY_NUMBER = "12345678";
-    private static final String COMPANY_NUMBER_ERR = "12345ERR";
+    private static final String COMPANY_NUMBER_RE = "RE123456";
     private static final String COMPANY_EMAIL_MOCK = "mockexistingemail@companieshouse.gov.uk";
 
 
@@ -24,7 +24,7 @@ class MockEmailRetrieverImplTest {
         @Test
         void testMockEmailAddressForTestCompany() throws ServiceException {
 
-            RegisteredEmailAddressJson response = mockEmailRetrieverImpl.getRegisteredEmailAddress(COMPANY_NUMBER_ERR);
+            RegisteredEmailAddressJson response = mockEmailRetrieverImpl.getRegisteredEmailAddress(COMPANY_NUMBER_RE);
             assertEquals(COMPANY_EMAIL_MOCK, response.getRegisteredEmailAddress());
         }
 

--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/livesbox/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/livesbox/vars
@@ -1,0 +1,5 @@
+environment = "livesbox"
+aws_profile = "live-eu-west-2"
+
+# service configs
+use_set_environment_files = true

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/stagsbox/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/stagsbox/vars
@@ -1,0 +1,10 @@
+environment = "stagsbox"
+aws_profile = "staging-eu-west-2"
+
+# service configs
+use_set_environment_files = true
+
+# Scheduled scaling of tasks
+service_autoscale_enabled  = true
+service_scaledown_schedule = "55 19 * * ? *"
+service_scaleup_schedule   = "5 6 * * ? *"


### PR DESCRIPTION
Prefix the company number with RE instead of suffixing with ERR to allow company number regex checks in authentication-service to pass. Lines up with the new prefix in test-data-generator