### PR TITLE
ASM-1864 Upgrade to Jackson 3.x 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.21</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <!-- Source: https://mvnrepository.com/artifact/org.mapstruct/mapstruct -->
         <org.mapstruct.version>1.6.3</org.mapstruct.version>
         <!-- Source: https://mvnrepository.com/artifact/org.webjars/swagger-ui -->
-        <swagger-ui.version>5.32.2</swagger-ui.version>
+        <swagger-ui.version>5.32.4</swagger-ui.version>
         <!-- Source: https://mvnrepository.com/artifact/org.owasp.encoder/encoder -->
         <encoder.version>1.4.0</encoder.version>
         <!-- Source: https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
@@ -80,9 +80,9 @@
         <structured-logging.version>3.0.54</structured-logging.version>
         <rest-service-common-library.version>2.0.11</rest-service-common-library.version>
         <api-helper-java-library.version>3.0.4</api-helper-java-library.version>
-        <private-api-sdk-java.version>4.0.494</private-api-sdk-java.version>
+        <private-api-sdk-java.version>5.0.0</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
-        <api-sdk-java.version>6.6.15</api-sdk-java.version>
+        <api-sdk-java.version>6.6.16</api-sdk-java.version>
 
         <!-- Sonar Properties -->
         <!--suppress XmlUnresolvedReference -->
@@ -189,7 +189,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-jackson2</artifactId>
+            <artifactId>spring-boot-starter-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -210,6 +210,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-opentelemetry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.21</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/interceptor/TransactionInterceptor.java
@@ -20,8 +20,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.registeredemailaddressapi.service.TransactionService;
 import uk.gov.companieshouse.registeredemailaddressapi.utils.ApiLogger;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
@@ -32,14 +31,20 @@ import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 @Component
 public class TransactionInterceptor implements HandlerInterceptor {
 
-    private final TransactionService transactionService;
     private static final Pattern TRANSACTION_ID_PATTERN = Pattern.compile(TRANSACTION_ID_REGEX);
 
+    private final TransactionService transactionService;
+
+    private final ObjectMapper objectMapper;
+
+
     @Autowired
-    public TransactionInterceptor(TransactionService transactionService) {
+    public TransactionInterceptor(TransactionService transactionService, ObjectMapper objectMapper) {
         this.transactionService = transactionService;
+        this.objectMapper = objectMapper;
     }
 
+    @SuppressWarnings("DuplicatedCode")
     @Override
     public boolean preHandle(HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler) throws IOException {
         @SuppressWarnings("unchecked")
@@ -58,7 +63,6 @@ public class TransactionInterceptor implements HandlerInterceptor {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             var errorsList = Map.of("errors", Map.of("error", "Invalid transaction id"));
             response.setContentType("application/json");
-            var objectMapper = new ObjectMapper();
             response.getWriter().write(objectMapper.writeValueAsString(errorsList));
             return false;
         }

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/interceptor/TransactionInterceptor.java
@@ -44,7 +44,6 @@ public class TransactionInterceptor implements HandlerInterceptor {
         this.objectMapper = objectMapper;
     }
 
-    @SuppressWarnings("DuplicatedCode")
     @Override
     public boolean preHandle(HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler) throws IOException {
         @SuppressWarnings("unchecked")

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/interceptor/UserAuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/interceptor/UserAuthenticationInterceptor.java
@@ -32,9 +32,9 @@ import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.TR
  * (based on path variable or transaction data) and has the company_rea=update
  * permission.
  * Checks are skipped if an API key is being used.
- *
+ * <br/>
  * Note component name override is required to avoid the following exception during initialisation of Spring application context
- *
+ * <br/>
  * Caused by: org.springframework.context.annotation.ConflictingBeanDefinitionException:
  * Annotation-specified bean name 'userAuthenticationInterceptor' for bean class [uk.gov.companieshouse.api.interceptor.UserAuthenticationInterceptor]
  * conflicts with existing, non-compatible bean definition of same name and class [uk.gov.companieshouse.registeredemailaddressapi.interceptor.UserAuthenticationInterceptor]

--- a/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/interceptor/UserAuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/registeredemailaddressapi/interceptor/UserAuthenticationInterceptor.java
@@ -32,9 +32,9 @@ import static uk.gov.companieshouse.registeredemailaddressapi.utils.Constants.TR
  * (based on path variable or transaction data) and has the company_rea=update
  * permission.
  * Checks are skipped if an API key is being used.
- * <br/>
+ * <p>
  * Note component name override is required to avoid the following exception during initialisation of Spring application context
- * <br/>
+ * <p>
  * Caused by: org.springframework.context.annotation.ConflictingBeanDefinitionException:
  * Annotation-specified bean name 'userAuthenticationInterceptor' for bean class [uk.gov.companieshouse.api.interceptor.UserAuthenticationInterceptor]
  * conflicts with existing, non-compatible bean definition of same name and class [uk.gov.companieshouse.registeredemailaddressapi.interceptor.UserAuthenticationInterceptor]

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/utils/Helper.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/integration/utils/Helper.java
@@ -3,11 +3,11 @@ package uk.gov.companieshouse.registeredemailaddressapi.integration.utils;
 import java.util.Random;
 import java.util.UUID;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.SerializationFeature;
-
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectWriter;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.model.company.RegisteredEmailAddressJson;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
@@ -18,6 +18,14 @@ import uk.gov.companieshouse.registeredemailaddressapi.model.dto.RegisteredEmail
 import uk.gov.companieshouse.registeredemailaddressapi.model.dto.RegisteredEmailAddressResponseData;
 
 public class Helper {
+
+    private final ObjectMapper mapper;
+
+    public Helper() {
+        mapper = JsonMapper.builder()
+                .configure(SerializationFeature.WRAP_ROOT_VALUE, false)
+                .build();
+    }
 
     public Transaction generateTransaction(){
         Transaction transaction = new Transaction();
@@ -75,11 +83,10 @@ public class Helper {
         registeredEmailAddressResponseDTO.setId(UUID.randomUUID().toString());
         return registeredEmailAddressResponseDTO;
     }
-    public String writeToJson(Object object) throws JsonProcessingException {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+
+    public String writeToJson(Object object) throws JacksonException {
         ObjectWriter ow = mapper.writer();
         return ow.writeValueAsString(object);
-
     }
+
 }

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/interceptor/TransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/interceptor/TransactionInterceptorTest.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.registeredemailaddressapi.unit.interceptor;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -7,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.servlet.HandlerMapping;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.registeredemailaddressapi.exception.ServiceException;
 import uk.gov.companieshouse.registeredemailaddressapi.interceptor.TransactionInterceptor;
@@ -16,7 +18,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -37,8 +41,15 @@ class TransactionInterceptorTest {
     @Mock
     private HttpServletRequest mockHttpServletRequest;
 
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     @InjectMocks
     private TransactionInterceptor transactionInterceptor;
+
+    @BeforeEach
+    void setUp() {
+        transactionInterceptor = new TransactionInterceptor(transactionService, objectMapper);
+    }
 
     @Test
     void testPreHandleIsSuccessful() throws Exception {

--- a/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/interceptor/TransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/registeredemailaddressapi/unit/interceptor/TransactionInterceptorTest.java
@@ -43,7 +43,6 @@ class TransactionInterceptorTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    @InjectMocks
     private TransactionInterceptor transactionInterceptor;
 
     @BeforeEach


### PR DESCRIPTION
## Description

Spring Boot now uses Jackson 3 as its preferred JSON library. Jackson 3 uses new group IDs and package names with com.fasterxml.jackson becoming tools.jackson. An exception to this is the jackson-annotations module which continues to use the com.fasterxml.jackson.core group ID and com.fasterxml.jackson.annotation package. To learn more about the changes in Jackson 3, refer to the [Jackson wiki](https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.0#major-changesfeatures-in-30).

Packages and dependencies have been updated to use the latest Jackson 3 libraries.

## Jira Ticket

[ASM-1864](https://companieshouse.atlassian.net/browse/ASM-1864)

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [ ] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [ ] API (Karate) tests passing
- [ ] Pulled latest master into feature branch
- [ ] Code reviewed
- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [ ] If your pull request depends on any other, please link them in the description


[ASM-1862]: https://companieshouse.atlassian.net/browse/ASM-1862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ+

[ASM-1864]: https://companieshouse.atlassian.net/browse/ASM-1864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ